### PR TITLE
Add support for Solaris and Illumos (1.13+)

### DIFF
--- a/uname_arch.sh
+++ b/uname_arch.sh
@@ -26,6 +26,7 @@ uname_arch() {
   arch=$(uname -m)
   case $arch in
     x86_64) arch="amd64" ;;
+    i86pc) arch="amd64" ;;
     x86) arch="386" ;;
     i686) arch="386" ;;
     i386) arch="386" ;;

--- a/uname_os.sh
+++ b/uname_os.sh
@@ -21,6 +21,16 @@ uname_os() {
     mingw*) os="windows" ;;
   esac
 
+  # Sun Solaris and derived OS (Illumos, Oracle Solaris) reports to be the very ancient SunOS via uname not what it actually is
+  if [ "$os" = "sunos" ]; then
+    # Current illumos versions have -o to check if they are illumos or Solaris without breaking most builds.
+    if [ $(uname -o) == "illumos" ]; then
+      os="illumos"
+    else
+      os="solaris"
+    fi
+  fi
+
   # other fixups here
   echo "$os"
 }

--- a/uname_os_check.sh
+++ b/uname_os_check.sh
@@ -17,6 +17,7 @@ uname_os_check() {
     openbsd) return 0 ;;
     plan9) return 0 ;;
     solaris) return 0 ;;
+    illumos) return 0 ;;
     windows) return 0 ;;
   esac
   log_crit "uname_os_check '$(uname -s)' got converted to '$os' which is not a GOOS value. Please file bug at https://github.com/client9/shlib"


### PR DESCRIPTION
This PR add support for Sun Solaris style uname and future changes in GOOS for Illumos.

The other shell commands are portable. 

i86pc can be 32 and 64 bit but go never got ported to i86pc 32bit so amd64 is sufficient.