### PR TITLE
fix travis.yml language error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: bash
+language: shell
 dist: xenial
 addons:
   apt:


### PR DESCRIPTION
fix -> language: value bash is an alias for shell, using shell