### PR TITLE
add sha256 command for FreeBSD and OpenBSD

### DIFF
--- a/hash_sha256.sh
+++ b/hash_sha256.sh
@@ -26,6 +26,9 @@ hash_sha256() {
     # darwin, freebsd?
     hash=$(shasum -a 256 "$TARGET" 2>/dev/null) || return 1
     echo "$hash" | cut -d ' ' -f 1
+  elif is_command sha256; then
+    hash=$(sha256 -q "$TARGET" 2>/dev/null) || return 1
+    echo "$hash" | cut -d ' ' -f 1
   elif is_command openssl; then
     hash=$(openssl -dst openssl dgst -sha256 "$TARGET") || return 1
     echo "$hash" | cut -d ' ' -f a


### PR DESCRIPTION
This makes `hash_sha256` work on FreeBSD and OpenBSD. Without this, `hash_sha256` falls back to `openssl` which does not support the flags used by shlib in the latest stable versions of FreeBSD or OpenBSD.