### PR TITLE
http_download_curl: fix failure handling and output message

### DIFF
--- a/http_download.sh
+++ b/http_download.sh
@@ -1,17 +1,15 @@
+# http_download_curl
+#
+# on error: displays a message on STDERR and returns non-zero code
 http_download_curl() {
   local_file=$1
   source_url=$2
   header=$3
   if [ -z "$header" ]; then
-    code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url")
+    curl -fsSL -o "$local_file" "$source_url"
   else
-    code=$(curl -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url")
+    curl -fsSL -H "$header" -o "$local_file" "$source_url"
   fi
-  if [ "$code" != "200" ]; then
-    log_debug "http_download_curl received HTTP status $code"
-    return 1
-  fi
-  return 0
 }
 
 # http_download_wget


### PR DESCRIPTION
Using a godownloader-generated sh script, GitHub would sometimes return a 302 (even though `curl -L -w '%{http_code}'` is provided...).

This replaces the *sometimes wrong* HTTP code checking logic with `curl`'s own.